### PR TITLE
RC 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 *~
 *\#
 npm-debug.log
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - "0.10"
+sudo: required

--- a/README.md
+++ b/README.md
@@ -1,3 +1,80 @@
 Response [![Build Status](https://travis-ci.org/B-Vladi/Response.svg?branch=master)](https://travis-ci.org/B-Vladi/Response)
 ========
 The extensible event-driven stateful interface.
+
+ * State(state)
+   * `.isState`
+   * `.create`
+   * `#EVENT_CHANGE_STATE`
+   * `#STATE_ERROR`
+   * `#isState`
+   * `#state`
+   * `#keys`
+   * `#data`
+   * `#stateData`
+   * `#invoke(method, args, context)`
+   * `#destroy()`
+   * `#destroyStateData()`
+   * `#is(state)`
+   * `#setState(state, data)`
+   * `#onState(state, listener, context)`
+   * `#onceState(state, listener, context)`
+   * `#onChangeState(listener, context)`
+   * `#offChangeState(listener)`
+   * `#setData(key, value)`
+   * `#getData(key)`
+   * `#toObject(keys)`
+   * `#getStateData(key)`
+   * `#toJSON()`
+
+ * Response(parent)
+   * `.State(state)`
+   * `.Queue(stack, start)`
+   * `.isResponse(object)`
+   * `.create(constructor, copyStatic)`
+   * `.resolve(results)`
+   * `.reject(reason)`
+   * `.nodeCallback(error, result)`
+   * `#State(state)`
+   * `#STATE_PENDING`
+   * `#STATE_RESOLVED`
+   * `#STATE_REJECTED`
+   * `#EVENT_PROGRESS`
+   * `#isResponse`
+   * `#pending()`
+   * `#resolve(results)`
+   * `#reject(reason)`
+   * `#progress(progress)`
+   * `#isPending()`
+   * `#isResolved()`
+   * `#isRejected()`
+   * `#then(onResolve, onReject, onProgress, context)`
+   * `#always(listener, context)`
+   * `#onPending(listener, context)`
+   * `#onResolve(listener, context)`
+   * `#notify(parent)`
+   * `#listen(response)`
+   * `#done()`
+   * `#getResult(key)`
+   * `#getReason()`
+   
+ * Queue(stack, start)
+   * `.create(constructor, copyStatic)`
+   * `.isQueue(object)`
+   * `#Response(parent)`
+   * `#EVENT_START`
+   * `#EVENT_STOP`
+   * `#EVENT_NEXT_ITEM`
+   * `#isQueue`
+   * `#isStrict`
+   * `#isStarted`
+   * `#item`
+   * `#start()`
+   * `#stop()`
+   * `#push()`
+   * `#getResults()`
+   * `#getReasons()`
+   * `#strict(flag)`
+   * `#onStart(listener, context)`
+   * `#onStop(listener, context)`
+   * `#onNextItem(listener, context)`

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ The extensible event-driven stateful interface.
  * State(state)
    * `.EVENT_CHANGE_STATE`
    * `.STATE_ERROR`
-   * `.isState`
+   * `.isState(object)`
    * `.create`
+   * `.invoke(method, args, context)`
    
    * `#isState`
    * `#state`
@@ -32,13 +33,13 @@ The extensible event-driven stateful interface.
    * `.STATE_RESOLVED`
    * `.STATE_REJECTED`
    * `.EVENT_PROGRESS`
-   * `.State(state)`
-   * `.Queue(stack, start)`
    * `.isResponse(object)`
    * `.create(constructor, copyStatic)`
    * `.resolve(results)`
    * `.reject(reason)`
-   * `.nodeCallback(error, result)`
+   * `.invoke(method, args, context)`
+   * `.State(state)`
+   * `.Queue(stack, start)`
    
    * `#State(state)`
    * `#isResponse`
@@ -50,12 +51,14 @@ The extensible event-driven stateful interface.
    * `#isResolved()`
    * `#isRejected()`
    * `#then(onResolve, onReject, onProgress, context)`
-   * `#always(listener, context)`
+   * `#any(listener, context)`
    * `#onPending(listener, context)`
    * `#onResolve(listener, context)`
    * `#notify(parent)`
    * `#listen(response)`
    * `#done()`
+   * `#map()`
+   * `#fork()`
    * `#getResult(key)`
    * `#getReason()`
    
@@ -64,6 +67,7 @@ The extensible event-driven stateful interface.
    * `.EVENT_STOP`
    * `.EVENT_NEXT_ITEM`
    * `.create(constructor, copyStatic)`
+   * `.invoke(method, args, context)`
    * `.isQueue(object)`
    * `.Response(parent)`
    
@@ -73,7 +77,7 @@ The extensible event-driven stateful interface.
    * `#item`
    * `#start()`
    * `#stop()`
-   * `#push()`
+   * `#push(item, key)`
    * `#strict(flag)`
    * `#onStart(listener, context)`
    * `#onStop(listener, context)`

--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@ Response [![Build Status](https://travis-ci.org/B-Vladi/Response.svg?branch=mast
 The extensible event-driven stateful interface.
 
  * State(state)
+   * `.EVENT_CHANGE_STATE`
+   * `.STATE_ERROR`
    * `.isState`
    * `.create`
-   * `#EVENT_CHANGE_STATE`
-   * `#STATE_ERROR`
+   
    * `#isState`
    * `#state`
    * `#keys`
    * `#data`
    * `#stateData`
    * `#invoke(method, args, context)`
-   * `#destroy()`
-   * `#destroyStateData()`
+   * `#destroy(recursive)`
    * `#is(state)`
    * `#setState(state, data)`
    * `#onState(state, listener, context)`
@@ -23,11 +23,15 @@ The extensible event-driven stateful interface.
    * `#offChangeState(listener)`
    * `#setData(key, value)`
    * `#getData(key)`
-   * `#toObject(keys)`
    * `#getStateData(key)`
+   * `#toObject(keys)`
    * `#toJSON()`
 
  * Response(parent)
+   * `.STATE_PENDING`
+   * `.STATE_RESOLVED`
+   * `.STATE_REJECTED`
+   * `.EVENT_PROGRESS`
    * `.State(state)`
    * `.Queue(stack, start)`
    * `.isResponse(object)`
@@ -35,11 +39,8 @@ The extensible event-driven stateful interface.
    * `.resolve(results)`
    * `.reject(reason)`
    * `.nodeCallback(error, result)`
+   
    * `#State(state)`
-   * `#STATE_PENDING`
-   * `#STATE_RESOLVED`
-   * `#STATE_REJECTED`
-   * `#EVENT_PROGRESS`
    * `#isResponse`
    * `#pending()`
    * `#resolve(results)`
@@ -59,12 +60,13 @@ The extensible event-driven stateful interface.
    * `#getReason()`
    
  * Queue(stack, start)
+   * `.EVENT_START`
+   * `.EVENT_STOP`
+   * `.EVENT_NEXT_ITEM`
    * `.create(constructor, copyStatic)`
    * `.isQueue(object)`
-   * `#Response(parent)`
-   * `#EVENT_START`
-   * `#EVENT_STOP`
-   * `#EVENT_NEXT_ITEM`
+   * `.Response(parent)`
+   
    * `#isQueue`
    * `#isStrict`
    * `#isStarted`
@@ -72,8 +74,6 @@ The extensible event-driven stateful interface.
    * `#start()`
    * `#stop()`
    * `#push()`
-   * `#getResults()`
-   * `#getReasons()`
    * `#strict(flag)`
    * `#onStart(listener, context)`
    * `#onStop(listener, context)`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The extensible event-driven stateful interface.
    * `.isState(object)`
    * `.create`
    * `.invoke(method, args, context)`
-   
+
    * `#isState`
    * `#state`
    * `#keys`
@@ -40,7 +40,7 @@ The extensible event-driven stateful interface.
    * `.invoke(method, args, context)`
    * `.State(state)`
    * `.Queue(stack, start)`
-   
+
    * `#State(state)`
    * `#isResponse`
    * `#pending()`
@@ -70,7 +70,7 @@ The extensible event-driven stateful interface.
    * `.invoke(method, args, context)`
    * `.isQueue(object)`
    * `.Response(parent)`
-   
+
    * `#isQueue`
    * `#isStrict`
    * `#isStarted`

--- a/Response.js
+++ b/Response.js
@@ -1334,6 +1334,7 @@ function emit(emitter, type, data) {
 
 function create(constructor, sp) {
     var proto;
+    var name;
 
     if (Object.create) {
         proto = Object.create(this.prototype, constructor ? {
@@ -1352,7 +1353,7 @@ function create(constructor, sp) {
 
     if (constructor) {
         if (sp === true) {
-            for (var name in this) {
+            for (name in this) {
                 if (this.hasOwnProperty(name)) {
                     constructor[name] = this[name];
                 }

--- a/Response.js
+++ b/Response.js
@@ -611,28 +611,6 @@ Response.reject = function (reason) {
     return response;
 };
 
-/**
- *
- * @param {Error|*} [error]
- * @param {...*} [results]
- */
-Response.nodeCallback = function responseNodeCallback(error, results) {
-    var index = arguments.length;
-    var args = [];
-
-    if (error == null) {
-        if (--index > 0) {
-            while (index) {
-                args[--index] = arguments[index + 1];
-            }
-        }
-
-        this.setState(STATE_RESOLVED, args);
-    } else {
-        this.reject(error);
-    }
-};
-
 Response.prototype = State.create(Response);
 
 /**
@@ -647,17 +625,6 @@ Response.prototype.State = State;
  * @default true
  */
 Response.prototype.isResponse = true;
-
-/**
- *
- * @param {Function} [callback=Response.nodeCallback]
- * @returns {Function}
- */
-Response.prototype.callback = function (callback) {
-    var _callback = isFunction(callback) ? callback : Response.nodeCallback;
-
-    return bind(_callback, this);
-};
 
 /**
  *

--- a/Response.js
+++ b/Response.js
@@ -316,7 +316,7 @@ State.prototype.is = function (state) {
 State.prototype.setState = function (state, data) {
     var _state = this.state !== state;
     var _hasData = arguments.length > 1;
-    var _data = _hasData ? wrapIfArray(data) : [];
+    var _data = _hasData ? wrapIfNotArray(data) : [];
 
     if (_state || _hasData) {
         this.stateData = _data;
@@ -1304,11 +1304,11 @@ function isItemRejected(item) {
 }
 
 /**
- *
+ * В случае, если аргумент не является массивом, то функция оборачивает его в массив
  * @param {*|Array} object
  * @returns {Array}
  */
-function wrapIfArray(object) {
+function wrapIfNotArray(object) {
     return isArray(object) ? object : [object];
 }
 

--- a/Response.js
+++ b/Response.js
@@ -19,6 +19,69 @@ var EVENT_STOP = 'stop';
 var EVENT_NEXT_ITEM = 'nextItem';
 
 /**
+ * @param {Object} proto
+ * @param {Function} constructor
+ * @type {Function}
+ */
+var defineConstructor = isFunction(Object.defineProperty) ? function (proto, constructor) {
+    Object.defineProperty(proto, 'constructor', {
+        value: constructor,
+        enumerable: false,
+        writable: true,
+        configurable: true
+    });
+} : function (proto, constructor) {
+    proto.constructor = constructor;
+};
+
+/**
+ * @function
+ * @param {*} object
+ */
+var getKeys = isFunction(Object.keys) ? Object.keys : function keys(object) {
+    var keys = [];
+
+    for (var name in object) {
+        if (object.hasOwnProperty(name)) {
+            keys.push(name);
+        }
+    }
+
+    return keys;
+};
+
+/**
+ * @function
+ * @param {*} object
+ */
+var isArray = isFunction(Array.isArray) ? Array.isArray : function isArray(object) {
+    return object && (toString.call(object) === '[object Array]');
+};
+
+/**
+ *
+ * @param {Function} [callback]
+ * @param {Object} [context]
+ * @returns {Function}
+ * @type {Function}
+ */
+var bind = isFunction(Function.prototype.bind) ? function (callback, context) {
+    return callback && callback.bind(context);
+} : function (callback, context) {
+    return callback && function () {
+            var index = 0;
+            var length = arguments.length;
+            var args = new Array(length);
+
+            while (index < length) {
+                args[index] = arguments[index++];
+            }
+
+            return callback.apply(context, args);
+        }
+};
+
+/**
  *
  * @param {*} [state] Начальное состояние объекта.
  * @returns {State}
@@ -1433,26 +1496,6 @@ function emit(emitter, type, data) {
 
 /**
  *
- * @param {Function} callback
- * @param {Object} context
- * @returns {Function}
- */
-function bind(callback, context) {
-    return isFunction(callback.bind) ? callback.bind(context) : function () {
-        var index = 0;
-        var length = arguments.length;
-        var args = new Array(length);
-
-        while (index < length) {
-            args[index] = arguments[index++];
-        }
-
-        return callback.apply(context, args);
-    };
-}
-
-/**
- *
  * @param {Object} from
  * @param {Object} to
  */
@@ -1487,19 +1530,6 @@ function inherits(superConst, constructor) {
     return proto;
 }
 
-function defineConstructor(proto, constructor) {
-    if (Object.defineProperty) {
-        Object.defineProperty(proto, 'constructor', {
-            value: constructor,
-            enumerable: false,
-            writable: true,
-            configurable: true
-        });
-    } else {
-        proto.constructor = constructor;
-    }
-}
-
 /**
  *
  * @constructor
@@ -1507,27 +1537,3 @@ function defineConstructor(proto, constructor) {
 function Prototype() {
     Prototype.prototype = null;
 }
-
-/**
- * @function
- * @param {*} object
- */
-var getKeys = isFunction(Object.keys) ? Object.keys : function keys(object) {
-    var keys = [];
-
-    for (var name in object) {
-        if (object.hasOwnProperty(name)) {
-            keys.push(name);
-        }
-    }
-
-    return keys;
-};
-
-/**
- * @function
- * @param {*} object
- */
-var isArray = isFunction(Array.isArray) ? Array.isArray : function isArray(object) {
-    return object && (toString.call(object) === '[object Array]');
-};

--- a/Response.js
+++ b/Response.js
@@ -889,6 +889,14 @@ Response.prototype.done = function () {
 
 /**
  *
+ * @returns {Response}
+ */
+Response.prototype.fork = function () {
+    return new Response(this);
+};
+
+/**
+ *
  * @example
  * var r = new Response()
  *   .resolve(3) // resolve one result

--- a/Response.js
+++ b/Response.js
@@ -31,7 +31,7 @@ function State(state) {
  * @static
  */
 State.isState = function (object) {
-    return object != null && ((object instanceof State) || object.isState);
+    return object != null && (object.isState || (object instanceof State));
 };
 
 /**
@@ -437,7 +437,7 @@ Response.Queue = Queue;
  * @returns {Boolean}
  */
 Response.isResponse = function (object) {
-    return object != null && ((object instanceof Response) || object.isResponse);
+    return object != null && (object.isResponse || (object instanceof Response));
 };
 
 /**
@@ -913,7 +913,7 @@ Queue.create = create;
  * @returns {Boolean}
  */
 Queue.isQueue = function (object) {
-    return object != null && ((object instanceof Queue) || object.isQueue);
+    return object != null && (object.isQueue || (object instanceof Queue));
 };
 
 Queue.prototype = Response.create(Queue);

--- a/Response.js
+++ b/Response.js
@@ -150,15 +150,15 @@ State.create = function (constructor, copyStatic) {
 /**
  *
  * @static
- * @param {Function} method
+ * @param {Function} fnc
  * @param {Array} [args]
  * @param {Object} [context]
  * @returns {State}
  */
-State.invoke = function (method, args, context) {
+State.invoke = function (fnc, args, context) {
     var state = new this();
 
-    state.invoke(method, args, context);
+    state.invoke(fnc, args, context);
 
     return state;
 };
@@ -204,12 +204,12 @@ State.prototype.stateData = null;
 
 /**
  *
- * @param {Function} method
+ * @param {Function} fnc
  * @param {Array} [args]
  * @param {*} [context=this]
  * @returns {*}
  */
-State.prototype.invoke = function (method, args, context) {
+State.prototype.invoke = function (fnc, args, context) {
     var _args = isArray(args) ? args : [];
     var ctx = context == null ? this : context;
     var result;
@@ -217,31 +217,31 @@ State.prototype.invoke = function (method, args, context) {
     try {
         switch (_args.length) {
             case 0:
-                result = method.call(ctx);
+                result = fnc.call(ctx);
                 break;
             case 1:
-                result = method.call(ctx, _args[0]);
+                result = fnc.call(ctx, _args[0]);
                 break;
             case 2:
-                result = method.call(ctx, _args[0], _args[1]);
+                result = fnc.call(ctx, _args[0], _args[1]);
                 break;
             case 3:
-                result = method.call(ctx, _args[0], _args[1], _args[2]);
+                result = fnc.call(ctx, _args[0], _args[1], _args[2]);
                 break;
             case 4:
-                result = method.call(ctx, _args[0], _args[1], _args[2], _args[3]);
+                result = fnc.call(ctx, _args[0], _args[1], _args[2], _args[3]);
                 break;
             case 5:
-                result = method.call(ctx, _args[0], _args[1], _args[2], _args[3], _args[4]);
+                result = fnc.call(ctx, _args[0], _args[1], _args[2], _args[3], _args[4]);
                 break;
             default:
-                result = method.apply(ctx, _args);
+                result = fnc.apply(ctx, _args);
         }
     } catch (error) {
         result = toError(error);
 
         if (this && this.isState) {
-            this.setState(STATE_ERROR, result);
+            this.setState(STATE_ERROR, [result]);
         }
     }
 
@@ -570,7 +570,7 @@ Response.create = State.create;
 /**
  *
  * @static
- * @param {Function} method
+ * @param {Function} fnc
  * @param {Array} [args]
  * @param {Object} [context]
  * @type {Function}
@@ -1002,7 +1002,7 @@ Queue.create = State.create;
 /**
  *
  * @static
- * @param {Function} method
+ * @param {Function} fnc
  * @param {Array} [args]
  * @param {Object} [context]
  * @type {Function}

--- a/Response.js
+++ b/Response.js
@@ -969,16 +969,16 @@ Response.prototype.getReason = function () {
 
 /**
  *
- * @param {Response[]|Promise[]|Function[]|*[]} [stack=[]]
+ * @param {Response[]|Promise[]|Function[]|*[]} [items=[]]
  * @param {Boolean} [start=false]
  * @constructor
  * @extends {Response}
  * @returns {Queue}
  */
-function Queue(stack, start) {
+function Queue(items, start) {
     this.Response();
 
-    this.stack = isArray(stack) ? stack : [];
+    this.items = isArray(items) ? items : [];
     this.item = null;
     this.isStarted = false;
     this.isStrict = this.isStrict;
@@ -986,7 +986,7 @@ function Queue(stack, start) {
         .onState(STATE_RESOLVED, this.stop)
         .onState(STATE_REJECTED, this.stop);
 
-    this.keys.length = this.stack.length;
+    this.keys.length = this.items.length;
 
     if (typeof start === 'boolean' && start) {
         this.start();
@@ -1072,7 +1072,7 @@ Queue.prototype.isStarted = false;
  * @type {Array}
  * @default null
  */
-Queue.prototype.stack = null;
+Queue.prototype.items = null;
 
 /**
  * @readonly
@@ -1110,7 +1110,7 @@ Queue.prototype.stop = function () {
         emit(this, EVENT_STOP, []);
 
         if (this.isResolved() || this.isRejected()) {
-            this.stack.length = 0;
+            this.items.length = 0;
         }
     }
 
@@ -1124,10 +1124,10 @@ Queue.prototype.stop = function () {
  * @returns {Queue}
  */
 Queue.prototype.push = function (item, name) {
-    var keyIndex = this.stack.length + this.stateData.length;
+    var keyIndex = this.items.length + this.stateData.length;
 
     this.keys[keyIndex] = arguments.length > 1 || item == null ? name : item.name;
-    this.stack.push(item);
+    this.items.push(item);
 
     return this;
 };
@@ -1148,7 +1148,7 @@ Queue.prototype.strict = function (flag) {
  */
 Queue.prototype.destroy = function (recursive) {
     if (recursive === true) {
-        destroyItems(this.stack.concat(this.stateData));
+        destroyItems(this.items.concat(this.stateData));
     }
 
     destroy(this);
@@ -1203,7 +1203,7 @@ module.exports = Response;
  * @param {Queue} queue
  */
 function iterate(queue) {
-    while (queue.stack.length) {
+    while (queue.items.length) {
         if (checkFunction(queue, queue.item) || checkResponse(queue, queue.item)) {
             return;
         }
@@ -1220,7 +1220,7 @@ function iterate(queue) {
  * @returns {Boolean}
  */
 function checkFunction(queue, item) {
-    var next = queue.stack.shift();
+    var next = queue.items.shift();
     var results;
 
     if (isFunction(next)) {

--- a/Response.js
+++ b/Response.js
@@ -799,18 +799,20 @@ Response.prototype.onProgress = function (listener, context) {
 
 /**
  *
- * @param {Response} parent
+ * @param {Response|Deferred} object
  * @throws {Error} Бросает исключение, если parent равен this.
  * @returns {Response}
  * @this {Response}
  */
-Response.prototype.notify = function (parent) {
-    if (parent) {
-        if (parent === this) {
+Response.prototype.notify = function (object) {
+    if (object) {
+        if (object === this) {
             throw new Error('Can\'t notify itself');
         }
 
-        this.then(parent.resolve, parent.reject, parent.progress, parent);
+        var onProgress = Response.isResponse(object) ? object.progress : object.notify;
+
+        this.then(object.resolve, object.reject, onProgress, object);
     }
 
     return this;

--- a/Response.js
+++ b/Response.js
@@ -897,6 +897,20 @@ Response.prototype.fork = function () {
 
 /**
  *
+ * @param {Function} listener
+ * @param {*} [context=this]
+ * @returns {Response}
+ */
+Response.prototype.map = function (listener, context) {
+    return this.onResolve(onMap, {
+        response: this,
+        listener: listener,
+        context: context
+    });
+};
+
+/**
+ *
  * @example
  * var r = new Response()
  *   .resolve(3) // resolve one result
@@ -1451,6 +1465,15 @@ function onAny() {
     this.response.off(this.response.isResolved() ? STATE_REJECTED : STATE_RESOLVED, onAny);
 
     invokeListener(this.response, this.listener, this.context);
+}
+
+/**
+ *
+ */
+function onMap () {
+    var response = this.response;
+
+    response.resolve(response.invoke(this.listener, response.stateData, this.context));
 }
 
 /**

--- a/Response.js
+++ b/Response.js
@@ -831,13 +831,13 @@ Response.prototype.notify = function (object) {
  *     resolve('success');
  *   }));
  *
- * @param {Response|Object} response
+ * @param {Response|Promise} object
  * @this {Response}
- * @throws {Error} Бросает исключение, если response равен this.
+ * @throws {Error} Бросает исключение, если object равен this.
  * @returns {Response}
  */
-Response.prototype.listen = function (response) {
-    if (response === this) {
+Response.prototype.listen = function (object) {
+    if (object === this) {
         throw new Error('Cannot listen on itself');
     }
 
@@ -845,11 +845,7 @@ Response.prototype.listen = function (response) {
         this.pending();
     }
 
-    if (response.then.length === 4) {
-        response.then(this.resolve, this.reject, this.progress, this);
-    } else {
-        response.then(bind(this.resolve, this), bind(this.reject, this), bind(this.progress, this));
-    }
+    then(object, this.resolve, this.reject, this.progress, this);
 
     return this;
 };
@@ -1383,6 +1379,22 @@ function tryEmit(emitter, type, data) {
 function emit(emitter, type, data) {
     if (emitter._events && emitter._events[type]) {
         tryEmit(emitter, type, data);
+    }
+}
+
+/**
+ *
+ * @param {Response|Object} object
+ * @param {Function} [resolve]
+ * @param {Function} [reject]
+ * @param {Function} [progress]
+ * @param {Object} [context]
+ */
+function then(object, resolve, reject, progress, context) {
+    if (object.then.length === 4) {
+        object.then(resolve, reject, progress, context);
+    } else {
+        object.then(bind(resolve, context), bind(reject, context), bind(progress, context));
     }
 }
 

--- a/Response.js
+++ b/Response.js
@@ -232,7 +232,7 @@ State.prototype.setState = function (state, stateData) {
  */
 State.prototype.onState = function (state, listener, context) {
     if (this.state === state) {
-        invoke(this, listener, context);
+        invokeListener(this, listener, context);
     }
 
     return this.on(state, listener, context);
@@ -256,7 +256,7 @@ State.prototype.onState = function (state, listener, context) {
  */
 State.prototype.onceState = function (state, listener, context) {
     if (this.state === state) {
-        invoke(this, listener, context);
+        invokeListener(this, listener, context);
     } else {
         this.once(state, listener, context);
     }
@@ -1285,7 +1285,7 @@ function toObject(item) {
     return (item && item.toObject) ? item.toObject() : item;
 }
 
-function invoke(emitter, listener, context) {
+function invokeListener(emitter, listener, context) {
     if (listener) {
         if (isFunction(listener)) {
             return emitter.invoke(listener, emitter.stateData, context);
@@ -1319,7 +1319,7 @@ function _emit (emitter, type, data) {
                 emitter.emit(type, data[0], data[1], data[2], data[3], data[4]);
                 break;
             default:
-                emitter.emit.apply(type, data);
+                emitter.emit.apply(emitter, [type].concat(data));
         }
     } catch (error) {
         emitter.setState(emitter.STATE_ERROR, toError(error));

--- a/Response.js
+++ b/Response.js
@@ -1061,19 +1061,14 @@ Queue.prototype.stop = function () {
 
 /**
  *
- * @param {Response|Function|*} item
+ * @param {Response|Promise|Function|*} item
  * @param {String} [name=item.name]
  * @returns {Queue}
  */
 Queue.prototype.push = function (item, name) {
-    if (arguments.length > 1) {
-        if (!isArray(this.keys)) {
-            this.keys = [];
-        }
+    var keyIndex = this.stack.length + this.stateData.length;
 
-        this.keys[this.stack.length + this.stateData.length] = name;
-    }
-
+    this.keys[keyIndex] = arguments.length > 1 || item == null ? name : item.name;
     this.stack.push(item);
 
     return this;

--- a/Response.js
+++ b/Response.js
@@ -1278,10 +1278,20 @@ function onRejectItem(error) {
     }
 }
 
+/**
+ *
+ * @param {Response|Promise} item
+ * @returns {Boolean}
+ */
 function isItemResolved(item) {
     return isFunction(item.isResolved) && item.isResolved();
 }
 
+/**
+ *
+ * @param {Response|Promise} item
+ * @returns {Boolean}
+ */
 function isItemRejected(item) {
     return isFunction(item.isRejected) && item.isRejected();
 }

--- a/Response.js
+++ b/Response.js
@@ -892,21 +892,21 @@ Response.prototype.getResult = function (key) {
             return toObject(this.getStateData(key));
             break;
         default:
-            if (this.stateData.length === 1) {
-                return toObject(this.stateData[0]);
-            } else {
-                return this.toObject(key);
-            }
+            var keys = isArray(key) ? key : this.keys;
+
+            return keys.length ? this.toObject(keys) : toObject(this.stateData[0]);
             break;
     }
 };
 
 /**
  *
- * @returns {Error|null}
+ * @returns {Error|undefined}
  */
 Response.prototype.getReason = function () {
-    return this.isRejected() ? this.stateData[0] : null;
+    if (this.isRejected()) {
+        return this.stateData[0];
+    }
 };
 
 /**

--- a/Response.js
+++ b/Response.js
@@ -861,8 +861,8 @@ Response.prototype.getResult = function (key) {
     }
 
     switch (typeof key) {
-        case 'String':
-        case 'Number':
+        case 'string':
+        case 'number':
             return toObject(this.getByKey(key));
             break;
         default:

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -6,7 +6,7 @@
         "benchmark" : "1.0.0"
     },
     "scripts": {
-        "test": "npm install && node start.js --harmony"
+        "test": "node start.js"
     },
     "private" : true
 }

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,0 +1,12 @@
+{
+    "name" : "Response-benchmark",
+    "version" : "0.0.36",
+    "dependencies": {
+        "Response": "git://github.com/B-Vladi/Response.git",
+        "benchmark" : "1.0.0"
+    },
+    "scripts": {
+        "test": "npm install && node start.js --harmony"
+    },
+    "private" : true
+}

--- a/benchmark/start.js
+++ b/benchmark/start.js
@@ -4,6 +4,11 @@ var Response = require('../Response');
 
 var or = new oldResponse();
 var r = new Response();
+var fnc = function () {};
+var response;
+var oQueue;
+var nQueue;
+var queue;
 
 var suits = [{
     name: '#destroy()',
@@ -12,6 +17,51 @@ var suits = [{
     },
     New: function () {
         new Response().destroy();
+    }
+}, {
+    name: '#resolve()',
+    fn: function () {
+        response.resolve().pending();
+    },
+    Old: {
+        onStart: function () {
+            response = new oldResponse().onState('resolve', fnc);
+        }
+    },
+    New: {
+        onStart: function () {
+            response = new Response().onState('resolve', fnc);
+        }
+    }
+}, {
+    name: '#progress()',
+    fn: function () {
+        response.progress();
+    },
+    Old: {
+        onStart: function () {
+            response = new oldResponse().onProgress(fnc);
+        }
+    },
+    New: {
+        onStart: function () {
+            response = new Response().onProgress(fnc);
+        }
+    }
+}, {
+    name: 'Queue#start()',
+    fn: function () {
+        queue.start().pending();
+    },
+    Old: {
+        onStart: function () {
+            queue = new oldResponse.Queue([fnc, fnc, fnc]);
+        }
+    },
+    New: {
+        onStart: function () {
+            queue = new Response.Queue([fnc, fnc, fnc]);
+        }
     }
 }];
 
@@ -34,8 +84,8 @@ while (index < length) {
     var suit = suits[index++];
 
     new Benchmark.Suite(suit.name)
-        .add('Old', suit.Old)
-        .add('New', suit.New)
+        .add('Old', suit.fn || suit.Old, suit.Old)
+        .add('New', suit.fn || suit.New, suit.New)
         .on('start', onStart)
         .on('cycle', onCycle)
         .on('complete', onComplete)

--- a/benchmark/start.js
+++ b/benchmark/start.js
@@ -19,17 +19,15 @@ var suits = [{
 }, {
     name: '#onResolve()',
     fn: function () {
-        response.onResolve(r);
+        response.onResolve(fnc);
     },
     Old: {
         onStart: function () {
-            r = new oldResponse().onResolve(fnc);
             response = new oldResponse().resolve();
         }
     },
     New: {
         onStart: function () {
-            r = new Response().onResolve(fnc);
             response = new Response().resolve();
         }
     }
@@ -88,17 +86,24 @@ var suits = [{
     }
 }, {
     name: 'Queue#start()',
-    fn: function () {
-        queue.start().pending();
-    },
     Old: {
         onStart: function () {
-            queue = new oldResponse.Queue([fnc, fnc, fnc]).onNextItem(fnc).onResolve(fnc);
+            r = new oldResponse().resolve();
+        },
+        fn: function () {
+            new oldResponse.Queue([r, r, r])
+                .onResolve(fnc)
+                .start();
         }
     },
     New: {
         onStart: function () {
-            queue = new Response.Queue([fnc, fnc, fnc]).onNextItem(fnc).onResolve(fnc);
+            r = new Response().resolve();
+        },
+        fn: function () {
+            new Response.Queue([r, r, r])
+                .onResolve(fnc)
+                .start();
         }
     }
 }];

--- a/benchmark/start.js
+++ b/benchmark/start.js
@@ -1,0 +1,43 @@
+var Benchmark = require('benchmark');
+var oldResponse = require('Response');
+var Response = require('../Response');
+
+var or = new oldResponse();
+var r = new Response();
+
+var suits = [{
+    name: '#destroy()',
+    Old: function () {
+        new oldResponse().destroy();
+    },
+    New: function () {
+        new Response().destroy();
+    }
+}];
+
+function onComplete() {
+    console.log('\tFastest is "' + this.filter('fastest').pluck('name') + '"\n');
+}
+
+function onStart() {
+    console.log(this.name + ':');
+}
+
+function onCycle(event) {
+    console.log('\t' + String(event.target));
+}
+
+var length = suits.length;
+var index = 0;
+
+while (index < length) {
+    var suit = suits[index++];
+
+    new Benchmark.Suite(suit.name)
+        .add('Old', suit.Old)
+        .add('New', suit.New)
+        .on('start', onStart)
+        .on('cycle', onCycle)
+        .on('complete', onComplete)
+        .run();
+}

--- a/benchmark/start.js
+++ b/benchmark/start.js
@@ -6,8 +6,6 @@ var or = new oldResponse();
 var r = new Response();
 var fnc = function () {};
 var response;
-var oQueue;
-var nQueue;
 var queue;
 
 var suits = [{
@@ -17,6 +15,23 @@ var suits = [{
     },
     New: function () {
         new Response().destroy();
+    }
+}, {
+    name: '#onResolve()',
+    fn: function () {
+        response.onResolve(r);
+    },
+    Old: {
+        onStart: function () {
+            r = new oldResponse().onResolve(fnc);
+            response = new oldResponse().resolve();
+        }
+    },
+    New: {
+        onStart: function () {
+            r = new Response().onResolve(fnc);
+            response = new Response().resolve();
+        }
     }
 }, {
     name: '#resolve()',
@@ -31,6 +46,21 @@ var suits = [{
     New: {
         onStart: function () {
             response = new Response().onState('resolve', fnc);
+        }
+    }
+}, {
+    name: '#reject()',
+    fn: function () {
+        response.reject().pending();
+    },
+    Old: {
+        onStart: function () {
+            response = new oldResponse().onState('reject', fnc);
+        }
+    },
+    New: {
+        onStart: function () {
+            response = new Response().onState('reject', fnc);
         }
     }
 }, {
@@ -49,18 +79,26 @@ var suits = [{
         }
     }
 }, {
+    name: 'new Queue().start()',
+    Old: function () {
+        new oldResponse.Queue([fnc, fnc, fnc], true);
+    },
+    New: function () {
+        new Response.Queue([fnc, fnc, fnc], true);
+    }
+}, {
     name: 'Queue#start()',
     fn: function () {
         queue.start().pending();
     },
     Old: {
         onStart: function () {
-            queue = new oldResponse.Queue([fnc, fnc, fnc]);
+            queue = new oldResponse.Queue([fnc, fnc, fnc]).onNextItem(fnc).onResolve(fnc);
         }
     },
     New: {
         onStart: function () {
-            queue = new Response.Queue([fnc, fnc, fnc]);
+            queue = new Response.Queue([fnc, fnc, fnc]).onNextItem(fnc).onResolve(fnc);
         }
     }
 }];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "Response",
     "author": "Vladislav Kurkin <b-vladi@cs-console.ru> (https://github.com/B-Vladi)",
-    "version": "0.0.35",
+    "version": "0.0.36",
     "main": "Response.js",
     "license": "MIT",
     "repository": {
@@ -12,7 +12,7 @@
         "node": "*"
     },
     "dependencies": {
-        "EventEmitter": "B-Vladi/EventEmitter.git#0.2.5"
+        "EventEmitter": "B-Vladi/EventEmitter.git#0.2.6"
     },
     "devDependencies": {
         "jasmine": "2.0.1",
@@ -21,14 +21,13 @@
         "karma-jasmine": "^0.2.3",
         "karma-browserify": "^2.0.0",
         "karma-chrome-launcher": "^0.1.5",
-        "karma-phantomjs-launcher": "^0.1.4",
-        "supertest": "^0.15.0"
+        "karma-phantomjs-launcher": "^0.1.4"
     },
     "bugs": {
         "email": "b-vladi@cs-console.ru",
         "url": "https://github.com/B-Vladi/Response/issues"
     },
     "scripts": {
-        "test": "echo '>> Starting PhantomJS tests ======' && ./node_modules/karma/bin/karma start; echo '>> Starting node tests ======' && jasmine"
+        "test": "echo '>> Starting PhantomJS tests ======' && npm install && ./node_modules/karma/bin/karma start; echo '>> Starting node tests ======' && jasmine"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "Response",
     "author": "Vladislav Kurkin <b-vladi@cs-console.ru> (https://github.com/B-Vladi)",
-    "version": "0.0.36",
+    "version": "0.1.0-rc1",
     "main": "Response.js",
     "license": "MIT",
     "repository": {

--- a/spec/Queue.spec.js
+++ b/spec/Queue.spec.js
@@ -96,23 +96,7 @@ describe('Queue:', function () {
         });
 
         describe('constructor:', function () {
-            describe('prototype', function () {
-                it('inherit', checkPrototype);
-
-                it('changed constants', function () {
-                    Const.prototype.EVENT_START = 'test1';
-                    Const.prototype.EVENT_STOP = 'test2';
-                    Const.prototype.EVENT_NEXT_ITEM = 'test3';
-
-                    new Const([1])
-                        .onStart(listener)
-                        .onStop(listener)
-                        .onNextItem(listener)
-                        .start();
-
-                    expect(listener.calls.count()).toBe(3);
-                });
-            });
+            it('inherit', checkPrototype);
 
             it('static methods', function () {
                 for (var name in Const) {

--- a/spec/Queue.spec.js
+++ b/spec/Queue.spec.js
@@ -9,17 +9,17 @@ describe('Queue:', function () {
 
     function checkProperties() {
         // Queue
-        expect(queue.stack).toEqual([]);
+        expect(queue.items).toEqual([]);
         expect(queue.item).toBeNull();
         expect(queue.isStrict).toBeFalsy();
         expect(queue.isStarted).toBeFalsy();
         expect(queue.isQueue).toBeTruthy();
     }
 
-    function checkQueue(state, stateData, stack, item, isStarted) {
+    function checkQueue(state, stateData, items, item, isStarted) {
         expect(queue.state).toBe(state);
         expect(queue.stateData).toEqual(stateData);
-        expect(queue.stack).toEqual(stack);
+        expect(queue.items).toEqual(items);
         expect(queue.item).toBe(item);
         expect(queue.isStarted).toBe(isStarted);
     }
@@ -61,33 +61,33 @@ describe('Queue:', function () {
         it('properties', checkProperties);
         it('type', checkType);
 
-        it('set stack', function () {
-            var stack = [1, 2, 3];
+        it('set items', function () {
+            var items = [1, 2, 3];
 
-            expect(new Queue(stack).stack).toBe(stack);
+            expect(new Queue(items).items).toBe(items);
         });
 
-        it('set empty stack', function () {
-            var stack = [];
+        it('set empty items', function () {
+            var items = [];
 
-            expect(new Queue(stack).stack).toBe(stack);
+            expect(new Queue(items).items).toBe(items);
         });
 
-        it('set invalid stack', function () {
-            expect(new Queue(1).stack).toEqual([]);
-            expect(new Queue('1').stack).toEqual([]);
-            expect(new Queue({}).stack).toEqual([]);
-            expect(new Queue(null).stack).toEqual([]);
-            expect(new Queue(undefined).stack).toEqual([]);
+        it('set invalid items', function () {
+            expect(new Queue(1).items).toEqual([]);
+            expect(new Queue('1').items).toEqual([]);
+            expect(new Queue({}).items).toEqual([]);
+            expect(new Queue(null).items).toEqual([]);
+            expect(new Queue(undefined).items).toEqual([]);
             expect(new Queue(function () {
-            }).stack).toEqual([]);
+            }).items).toEqual([]);
         });
     });
 
     describe('check inheritance for', function () {
         beforeEach(function () {
-            Const = function (stack, start) {
-                Queue.call(this, stack, start);
+            Const = function (items, start) {
+                Queue.call(this, items, start);
             };
 
             Queue.create(Const, true);
@@ -145,14 +145,14 @@ describe('Queue:', function () {
         expect(queue === Queue.prototype).toBeFalsy();
     });
 
-    describe('stack', function () {
-        it('result of the queue must match stack', function () {
+    describe('items', function () {
+        it('result of the queue must match items', function () {
             expect(new Queue([1, function () {
                 return 2;
             }, {}], true).stateData).toEqual([1, 2, {}]);
         });
 
-        it('the execution order must match the stack', function () {
+        it('the execution order must match the items', function () {
             var callStack = [];
 
             function i1() {
@@ -234,17 +234,17 @@ describe('Queue:', function () {
             expect(listener.calls.count()).toBe(2);
         });
 
-        it('push in stack', function () {
+        it('push in items', function () {
             queue = new Queue([0]).push(1);
 
-            expect(queue.stack).toEqual([0, 1]);
+            expect(queue.items).toEqual([0, 1]);
 
             queue.start();
 
             expect(queue.stateData).toEqual([0, 1]);
         });
 
-        it('push in stack with key', function () {
+        it('push in items with key', function () {
             var i0 = 0;
             var i1 = 1;
             var i2 = function name() {
@@ -259,14 +259,14 @@ describe('Queue:', function () {
                 .push(i3, 'value');
 
             expect(queue.keys).toEqual([undefined, '1', 'name', 'value', 'name', 'value']);
-            expect(queue.stack).toEqual([i0, i1, i2, i2, i3, i3]);
+            expect(queue.items).toEqual([i0, i1, i2, i2, i3, i3]);
         });
 
-        it('dynamic push in stack', function () {
+        it('dynamic push in items', function () {
             queue = new Queue([function () {
                 this.push(listener);
 
-                expect(this.stack).toEqual([listener]);
+                expect(this.items).toEqual([listener]);
             }], true);
 
             expect(listener.calls.count()).toBe(1);
@@ -312,7 +312,7 @@ describe('Queue:', function () {
             expect(listener.calls.mostRecent().object).toBe(ctx);
         });
 
-        it('on "nextItem" event (mould not be called if stack is empty)', function () {
+        it('on "nextItem" event (mould not be called if items is empty)', function () {
             expect(queue.onNextItem(listener)).toBe(queue);
 
             queue.start();
@@ -351,7 +351,7 @@ describe('Queue:', function () {
     });
 
     describe('destroy', function () {
-        it('should destroyed items in stack and in results', function () {
+        it('should destroyed items in items and in results', function () {
             var resp0 = new Response();
             var resp1 = new Response().resolve(resp0);
             var resp2 = new Response().resolve();
@@ -397,7 +397,7 @@ describe('Queue:', function () {
                 expect(listener).not.toHaveBeenCalled();
             });
 
-            it('if stack is empty, queue should be changed state to "resolve"', function () {
+            it('if items is empty, queue should be changed state to "resolve"', function () {
                 expect(new Queue([], true).state).toBe('resolve');
             });
         });
@@ -421,7 +421,7 @@ describe('Queue:', function () {
                 expect(listener.calls.count()).toBe(2);
             });
 
-            it('if stack is empty, queue should be emit "start" and "stop" events', function () {
+            it('if items is empty, queue should be emit "start" and "stop" events', function () {
                 queue
                     .on('start', listener)
                     .on('stop', listener)
@@ -518,7 +518,7 @@ describe('Queue:', function () {
             expect(queue.stop()).toBe(queue);
         });
 
-        it('in stack item', function () {
+        it('in items', function () {
             queue = new Queue([function () {
                 this.stop();
                 return 1;

--- a/spec/Queue.spec.js
+++ b/spec/Queue.spec.js
@@ -278,7 +278,7 @@ describe('Queue:', function () {
         expect(queue.strict()).toBe(queue);
         expect(queue.isStrict).toBeTruthy();
         expect(queue.strict(false).isStrict).toBeFalsy();
-        expect(queue.strict(true)).toBeTruthy();
+        expect(queue.strict(true).isStrict).toBeTruthy();
     });
 
     describe('subscribe', function () {
@@ -598,6 +598,21 @@ describe('Queue:', function () {
 
             checkQueue('error', [new Error('error')], [], null, false);
             expect(listener).toHaveBeenCalled();
+        });
+    });
+
+    describe('current item', function () {
+        it('should be previous object', function () {
+            var r1 = Response.resolve();
+            var r2 = Response.resolve();
+
+            new Queue([r1, function () {
+                expect(this.item).toBe(r1);
+
+                return r2;
+            }, function () {
+                expect(this.item).toBe(r2);
+            }], true);
         });
     });
 });

--- a/spec/Queue.spec.js
+++ b/spec/Queue.spec.js
@@ -14,10 +14,14 @@ describe('Queue:', function () {
         expect(queue.isStrict).toBeFalsy();
         expect(queue.isStarted).toBeFalsy();
         expect(queue.isQueue).toBeTruthy();
+    }
 
-        expect(queue.EVENT_START).toBe('start');
-        expect(queue.EVENT_STOP).toBe('stop');
-        expect(queue.EVENT_NEXT_ITEM).toBe('nextItem');
+    function checkQueue(state, stateData, stack, item, isStarted) {
+        expect(queue.state).toBe(state);
+        expect(queue.stateData).toEqual(stateData);
+        expect(queue.stack).toEqual(stack);
+        expect(queue.item).toBe(item);
+        expect(queue.isStarted).toBe(isStarted);
     }
 
     function checkInherit() {
@@ -44,7 +48,10 @@ describe('Queue:', function () {
 
     it('check exports', function () {
         expect(typeof Queue).toBe('function');
-        expect(typeof Response.queue).toBe('function');
+
+        expect(Queue.EVENT_START).toBe('start');
+        expect(Queue.EVENT_STOP).toBe('stop');
+        expect(Queue.EVENT_NEXT_ITEM).toBe('nextItem');
     });
 
     it('check constructor: prototype', checkPrototype);
@@ -154,13 +161,240 @@ describe('Queue:', function () {
         expect(queue === Queue.prototype).toBeFalsy();
     });
 
-    it('create queue via static method', function () {
-        queue = Response.queue(1, {}, listener);
+    describe('stack', function () {
+        it('result of the queue must match stack', function () {
+            expect(new Queue([1, function () {
+                return 2;
+            }, {}], true).stateData).toEqual([1, 2, {}]);
+        });
 
-        expect(Queue.isQueue(queue)).toBeTruthy();
-        expect(queue.stack).toEqual([1, {}, listener]);
-        expect(queue.state).toBe('pending');
+        it('the execution order must match the stack', function () {
+            var callStack = [];
+
+            function i1() {
+                callStack.push(1);
+            }
+
+            function i2() {
+                callStack.push(2);
+            }
+
+            function i3() {
+                callStack.push(3);
+            }
+
+            new Queue([i1, i2, i3], true);
+
+            expect(callStack).toEqual([1, 2, 3]);
+        });
+
+        it('queue should be wait if function returned pending response object', function () {
+            var r = new Response();
+            queue = new Queue([function () {
+                return r;
+            }], true);
+
+            expect(queue.state).toBe('pending');
+
+            r.resolve();
+
+            expect(queue.state).toBe('resolve');
+        });
+
+        it('queue should not be rejected if a function has thrown an exception', function () {
+            queue = new Queue([function () {
+                throw 'error';
+            }])
+                .start();
+
+            checkQueue('resolve', [new Error('error')], [], null, false);
+        });
+
+        it('strict queue should be rejected if a function has thrown an exception', function () {
+            queue = new Queue([function () {
+                throw 'error';
+            }, listener])
+                .strict()
+                .start();
+
+            checkQueue('error', [new Error('error')], [], null, false);
+            expect(listener).not.toHaveBeenCalled();
+        });
+
+        it('check items as response', function () {
+            var r1 = new Response();
+            var r2 = new Response();
+            var r3 = new Response().resolve();
+
+            queue = new Queue([r1, r2, r3], true);
+
+            checkQueue('pending', [r1], [r2, r3], r1, true);
+
+            r1.resolve();
+
+            checkQueue('pending', [r1, r2], [r3], r2, true);
+
+            r2.resolve();
+
+            checkQueue('resolve', [r1, r2, r3], [], null, false);
+        });
+
+        it('strict queue should be rejected if item is rejected', function () {
+            queue = new Queue([new Response().reject('error')])
+                .on('error', listener)
+                .on('stop', listener)
+                .strict()
+                .start();
+
+            checkQueue('error', [new Error('error')], [], null, false);
+            expect(listener.calls.count()).toBe(2);
+        });
+
+        it('push in stack', function () {
+            queue = new Queue([0]).push(1);
+
+            expect(queue.stack).toEqual([0, 1]);
+
+            queue.start();
+
+            expect(queue.stateData).toEqual([0, 1]);
+        });
+
+        it('push in stack with key', function () {
+            var i0 = 0;
+            var i1 = 1;
+            var i2 = function name() {
+            };
+            var i3 = {name: 'name'};
+
+            queue = new Queue([i0])
+                .push(i1, '1')
+                .push(i2)
+                .push(i2, 'value')
+                .push(i3)
+                .push(i3, 'value');
+
+            expect(queue.keys).toEqual([undefined, '1', 'name', 'value', 'name', 'value']);
+            expect(queue.stack).toEqual([i0, i1, i2, i2, i3, i3]);
+        });
+
+        it('dynamic push in stack', function () {
+            queue = new Queue([function () {
+                this.push(listener);
+
+                expect(this.stack).toEqual([listener]);
+            }], true);
+
+            expect(listener.calls.count()).toBe(1);
+        });
+    });
+
+    it('set strict', function () {
         expect(queue.isStrict).toBeFalsy();
+        expect(queue.strict()).toBe(queue);
+        expect(queue.isStrict).toBeTruthy();
+        expect(queue.strict(false).isStrict).toBeFalsy();
+        expect(queue.strict(true)).toBeTruthy();
+    });
+
+    describe('subscribe', function () {
+        var ctx = {};
+
+        it('on "start" event', function () {
+            expect(queue.onStart(listener)).toBe(queue);
+
+            queue.start();
+
+            expect(listener.calls.mostRecent().object).toBe(queue);
+        });
+
+        it('on "start" event (custom context)', function () {
+            queue.onStart(listener, ctx).start();
+
+            expect(listener.calls.mostRecent().object).toBe(ctx);
+        });
+
+        it('on "stop" event', function () {
+            expect(queue.onStop(listener)).toBe(queue);
+
+            queue.start();
+
+            expect(listener.calls.mostRecent().object).toBe(queue);
+        });
+
+        it('on "stop" event (custom context)', function () {
+            queue.onStop(listener, ctx).start();
+
+            expect(listener.calls.mostRecent().object).toBe(ctx);
+        });
+
+        it('on "nextItem" event (mould not be called if stack is empty)', function () {
+            expect(queue.onNextItem(listener)).toBe(queue);
+
+            queue.start();
+
+            expect(listener.calls.count()).toBe(0);
+        });
+
+        it('on "nextItem" event should be called with current item in argument', function () {
+            queue
+                .push(1)
+                .onNextItem(function (item) {
+                    expect(item).toBe(this.item);
+                })
+                .start();
+        });
+
+        it('event "nextItem" should be called on every item', function () {
+            queue
+                .push(1)
+                .push(2)
+                .push(3)
+                .onNextItem(listener)
+                .start();
+
+            expect(listener.calls.count()).toBe(3);
+        });
+
+        it('on "nextItem" event (custom context)', function () {
+            queue
+                .push(1)
+                .onNextItem(listener, ctx)
+                .start();
+
+            expect(listener.calls.mostRecent().object).toBe(ctx);
+        });
+    });
+
+    describe('destroy', function () {
+        it('should destroyed items in stack and in results', function () {
+            var resp0 = new Response();
+            var resp1 = new Response().resolve(resp0);
+            var resp2 = new Response().resolve();
+            var property;
+
+            new Queue([resp1, function () {
+                this.destroy(true);
+
+                for (property in resp0) {
+                    if (resp0.hasOwnProperty(property)) {
+                        expect(resp0[property]).toBeUndefined();
+                    }
+                }
+
+                for (property in resp1) {
+                    if (resp1.hasOwnProperty(property)) {
+                        expect(resp1[property]).toBeUndefined();
+                    }
+                }
+
+                for (property in resp2) {
+                    if (resp2.hasOwnProperty(property)) {
+                        expect(resp2[property]).toBeUndefined();
+                    }
+                }
+            }, resp2], true);
+        });
     });
 
     describe('start queue', function () {
@@ -237,29 +471,7 @@ describe('Queue:', function () {
                 expect(listener.calls.count()).toBe(1);
             });
 
-            it('start queue after stopping', function () {
-                var stack = [function () {
-                    this.stop();
-                    return 1;
-                }, listener];
-
-                queue = new Queue(stack, true);
-
-                expect(listener).not.toHaveBeenCalled();
-                expect(queue.isStarted).toBe(false);
-                expect(queue.item).toBe(1);
-                expect(queue.stateData).toEqual([]);
-                expect(queue.stack).toEqual(stack);
-                expect(queue.state).toBe('pending');
-
-                queue.start();
-
-                expect(listener.calls.count()).toBe(1);
-                expect(queue.stateData).toEqual([1, undefined]);
-                expect(queue.state).toBe('resolve');
-            });
-
-            it('start listener should be called without arguments and  with of queue context', function () {
+            it('start listener should be called without arguments and with of queue context', function () {
                 queue
                     .on('start', listener)
                     .start();
@@ -269,300 +481,139 @@ describe('Queue:', function () {
             });
         });
 
-        describe('stop queue', function () {
-            it('check returns value', function () {
-                expect(queue.stop()).toBe(queue);
-            });
-
-            it('in stack item', function () {
-                new Queue([function () {
-                    this.stop();
-                }, listener], true);
-
-                expect(listener).not.toHaveBeenCalled();
-            });
-
-            it('in "start" event listener', function () {
-                queue = new Queue([listener])
-                    .on('start', function () {
-                        this.stop();
-                    })
-                    .start();
-
-                expect(listener).not.toHaveBeenCalled();
-                expect(queue.isStarted).toBe(false);
-                expect(queue.item).toBe(null);
-                expect(queue.stateData).toEqual([]);
-                expect(queue.stack).toEqual([listener]);
-                expect(queue.state).toBe('pending');
-            });
-
-            it('in "nextItem" event listener', function () {
-                queue = new Queue([1, 2])
-                    .on('stop', listener)
-                    .on('nextItem', function () {
-                        this.stop();
-                    })
-                    .start();
-
-                expect(listener).toHaveBeenCalled();
-                expect(queue.isStarted).toBe(false);
-                expect(queue.item).toBe(1);
-                expect(queue.stateData).toEqual([]);
-                expect(queue.stack).toEqual([1, 2]);
-                expect(queue.state).toBe('pending');
-            });
-
-            it('queue should not emit "stop" event, if it is  stopped', function () {
-                queue
-                    .onStop(listener)
-                    .stop();
-
-                expect(listener).not.toHaveBeenCalled();
-            });
-
-            it('queue should be stopped on resolve or reject', function () {
-                new Queue([function () {
-                    this.resolve();
-                }, 2])
-                    .on('stop', listener)
-                    .start();
-
-                expect(listener).toHaveBeenCalled();
-                expect(queue.stateData).toEqual([]);
-                expect(queue.stack).toEqual([]);
-                expect(queue.item).toBeNull();
-            });
-        });
-
-        describe('stack', function () {
-            it('result of the queue must match stack', function () {
-                expect(new Queue([1, function () {
-                    return 2;
-                }, {}], true).stateData).toEqual([1, 2, {}]);
-            });
-
-            it('argument of function should be last element of stack or result of response or null', function () {
-                var r = new Response().resolve(2);
-
-                queue = new Queue([function (i) {
-                    expect(i).toBeNull();
-                    return 1;
-                }, function (i) {
-                    expect(i).toBe(1);
-                }, r, function (i) {
-                    expect(i).toBe(2);
-                }], true);
-            });
-
-            it('the execution order must match the stack', function () {
-                var callStack = [];
-
-                function i1(i) {
-                    callStack.push(1);
-                }
-
-                function i2(i) {
-                    callStack.push(2);
-                }
-
-                function i3(i) {
-                    callStack.push(3);
-                }
-
-                new Queue([i1, i2, i3], true);
-
-                expect(callStack).toEqual([1, 2, 3]);
-            });
-
-            it('queue should be wait if function returned pending response object', function () {
+        describe('after stopping', function () {
+            it('in task, response was resolved', function () {
                 var r = new Response();
-                queue = new Queue([function () {
-                    return r;
-                }], true);
 
-                expect(queue.state).toBe('pending');
+                queue = new Queue([function () {
+                    this.stop();
+                    return r;
+                }])
+                    .start();
 
                 r.resolve();
 
-                expect(queue.state).toBe('resolve');
+                checkQueue('pending', [r], [], r, false);
+
+                queue.start();
+
+                checkQueue('resolve', [r], [], null, false);
             });
 
-            it('queue should not be rejected if a function has thrown an exception', function () {
-                queue = new Queue([function () {
-                    throw 'error';
-                }], true);
-
-                expect(queue.state).toBe('resolve');
-                expect(queue.stateData).toEqual([new Error('error')]);
-            });
-
-            it('strict queue should be rejected if a function has thrown an exception', function () {
-                queue = new Queue([function () {
-                    throw 'error';
-                }, listener])
-                    .strict()
-                    .start();
-
-                expect(queue.state).toBe('error');
-                expect(queue.stateData).toEqual([new Error('error')]);
-                expect(listener).not.toHaveBeenCalled();
-            });
-
-            it('check items as response', function () {
-                var r1 = new Response();
-                var r2 = new Response();
-                var r3 = new Response().resolve();
-
-                queue = new Queue([r1, r2, r3], true);
-
-                expect(queue.stack).toEqual([r1, r2, r3]);
-                expect(queue.stateData).toEqual([]);
-                expect(queue.item).toBe(r1);
-                expect(queue.state).toBe('pending');
-
-                r1.resolve();
-
-                expect(queue.stack).toEqual([r2, r3]);
-                expect(queue.stateData).toEqual([r1]);
-                expect(queue.item).toBe(r2);
-                expect(queue.state).toBe('pending');
-
-                r2.resolve();
-
-                expect(queue.stack).toEqual([]);
-                expect(queue.stateData).toEqual([r1, r2, r3]);
-                expect(queue.item).toBeNull();
-                expect(queue.state).toBe('resolve');
-            });
-
-            it('strict queue should be rejected if item is rejected', function () {
-                var r = new Response().reject('error');
+            it('and response was resolved', function () {
+                var r = new Response();
 
                 queue = new Queue([r])
-                    .on('error', listener)
-                    .on('stop', listener)
-                    .strict()
-                    .start();
+                    .start()
+                    .stop();
 
-                expect(queue.state).toBe('error');
-                expect(queue.stateData).toEqual([new Error('error')]);
-                expect(queue.item).toBe(r);
-                expect(listener.calls.count()).toBe(2);
-            });
-
-            it('push in stack', function () {
-                queue = new Queue([0]).push(1, null, {});
-
-                expect(queue.stack).toEqual([0, 1, null, {}]);
+                r.resolve();
 
                 queue.start();
 
-                expect(queue.stateData).toEqual([0, 1, null, {}]);
+                checkQueue('resolve', [r], [], null, false);
             });
 
-            it('dynamic push in stack', function () {
-                queue = new Queue([function () {
-                    this.push(listener);
-                }], true);
+            it('and response was pending', function () {
+                var r = new Response();
 
-                expect(listener.calls.count()).toBe(1);
+                queue = new Queue([r])
+                    .start()
+                    .stop()
+                    .start();
+
+                r.resolve();
+
+                checkQueue('resolve', [r], [], null, false);
             });
         });
+    });
 
-        it('set strict', function () {
-            expect(queue.isStrict).toBeFalsy();
-            expect(queue.strict()).toBe(queue);
-            expect(queue.isStrict).toBeTruthy();
-            expect(queue.strict(false).isStrict).toBeFalsy();
-            expect(queue.strict(true)).toBeTruthy();
+    describe('stop queue', function () {
+        it('check returns value', function () {
+            expect(queue.stop()).toBe(queue);
         });
 
-        describe('subscribe', function () {
-            var ctx = {};
+        it('in stack item', function () {
+            queue = new Queue([function () {
+                this.stop();
+                return 1;
+            }, listener])
+                .start();
 
-            it('on "start" event', function () {
-                expect(queue.onStart(listener)).toBe(queue);
+            checkQueue('pending', [1], [listener], 1, false);
+            expect(listener).not.toHaveBeenCalled();
 
-                queue.start();
+            queue.start();
 
-                expect(listener.calls.mostRecent().object).toBe(queue);
-            });
-
-            it('on "start" event (custom context)', function () {
-                queue.onStart(listener, ctx).start();
-
-                expect(listener.calls.mostRecent().object).toBe(ctx);
-            });
-
-            it('on "stop" event', function () {
-                expect(queue.onStop(listener)).toBe(queue);
-
-                queue.start();
-
-                expect(listener.calls.mostRecent().object).toBe(queue);
-            });
-
-            it('on "stop" event (custom context)', function () {
-                queue.onStop(listener, ctx).start();
-
-                expect(listener.calls.mostRecent().object).toBe(ctx);
-            });
-
-            it('on "nextItem" event (mould not be called if stack is empty)', function () {
-                expect(queue.onNextItem(listener)).toBe(queue);
-
-                queue.start();
-
-                expect(listener.calls.count()).toBe(0);
-            });
-
-            it('on "nextItem" event should be called with current item in argument', function () {
-                queue
-                    .push(1)
-                    .onNextItem(function (item) {
-                        expect(item).toBe(this.item);
-                    })
-                    .start();
-            });
-
-            it('event "nextItem" should be called on every item', function () {
-                queue
-                    .push(1, 2, 3)
-                    .onNextItem(listener)
-                    .start();
-
-                expect(listener.calls.count()).toBe(3);
-            });
-
-            it('on "nextItem" event (custom context)', function () {
-                queue
-                    .push(1)
-                    .onNextItem(listener, ctx)
-                    .start();
-
-                expect(listener.calls.mostRecent().object).toBe(ctx);
-            });
+            checkQueue('resolve', [1, undefined], [], null, false);
+            expect(listener).toHaveBeenCalled();
         });
 
-        it('destroy items', function () {
-            var resp1 = new Response().resolve();
-            var resp2 = new Response().resolve();
-            var property;
+        it('in "start" event listener', function () {
+            queue = new Queue([listener])
+                .on('start', function () {
+                    this.stop();
+                })
+                .start();
 
-            new Queue([resp1, resp2], true).destroyItems();
+            checkQueue('pending', [], [listener], null, false);
+            expect(listener).not.toHaveBeenCalled();
 
-            for (property in resp1) {
-                if (resp1.hasOwnProperty(property)) {
-                    expect(resp1[property]).toBeNull();
-                }
-            }
+            queue.start();
 
-            for (property in resp2) {
-                if (resp2.hasOwnProperty(property)) {
-                    expect(resp2[property]).toBeNull();
-                }
-            }
+            checkQueue('pending', [], [listener], null, false);
+            expect(listener).not.toHaveBeenCalled();
+        });
+
+        it('in "nextItem" event listener', function () {
+            queue = new Queue([1, 2])
+                .on('stop', listener)
+                .on('nextItem', function () {
+                    this.stop();
+                })
+                .start();
+
+            checkQueue('pending', [1], [2], 1, false);
+
+            queue.start();
+
+            checkQueue('pending', [1, 2], [], 2, false);
+
+            queue.start();
+
+            checkQueue('resolve', [1, 2], [], null, false);
+            expect(listener.calls.count()).toBe(3);
+        });
+
+        it('should not emit "stop" event, if it is stopped', function () {
+            queue
+                .onStop(listener)
+                .stop();
+
+            expect(listener).not.toHaveBeenCalled();
+        });
+
+        it('should be stopped on resolve in task', function () {
+            queue = new Queue([function () {
+                this.resolve();
+            }, 2])
+                .on('stop', listener)
+                .start();
+
+            checkQueue('resolve', [], [], null, false);
+            expect(listener).toHaveBeenCalled();
+        });
+
+        it('should be stopped on reject in task', function () {
+            queue = new Queue([function () {
+                this.reject('error');
+            }, 2])
+                .on('stop', listener)
+                .start();
+
+            checkQueue('error', [new Error('error')], [], null, false);
+            expect(listener).toHaveBeenCalled();
         });
     });
 });

--- a/spec/State.spec.js
+++ b/spec/State.spec.js
@@ -465,6 +465,51 @@ describe('State:', function () {
         });
     });
 
+    describe('getStateData', function () {
+        it('should returns undefined if a data of state  are missing', function () {
+            expect(state.getStateData(1)).toBeUndefined();
+        });
+
+        it('should returns undefined if key is not defined', function () {
+            expect(state
+                .setState('state', ['data'])
+                .setKeys([1])
+                .getStateData(2))
+                .toBeUndefined();
+        });
+
+        it('should be returns undefined if keys is empty', function () {
+            expect(state
+                .setState('state', ['data'])
+                .getStateData(1))
+                .toBeUndefined();
+        });
+
+        it('key should be strict equal', function () {
+            expect(state
+                .setState('state', ['data'])
+                .setKeys([1])
+                .getStateData('1'))
+                .toBeUndefined();
+        });
+
+        it('must return data', function () {
+            expect(state
+                .setState('state', ['data'])
+                .setKeys(['1'])
+                .getStateData('1'))
+                .toBe('data');
+        });
+
+        it('must return latest value', function () {
+            expect(state
+                .setState('state', ['data1', 'data2'])
+                .setKeys(['1', '1'])
+                .getStateData('1'))
+                .toBe('data2');
+        });
+    });
+
     it('destroy', function () {
         state
             .on(1, function () {
@@ -543,6 +588,12 @@ describe('State:', function () {
 
             expect(listener.calls.mostRecent().object).toBe(ctx);
         });
+
+        it('Should remain in the same state if no error', function () {
+            state.setState(1).invoke(listener);
+
+            expect(state.state).toBe(1);
+        })
     });
 
     describe('toObject', function () {
@@ -621,6 +672,15 @@ describe('State:', function () {
                 .toObject(['first']))
                 .toEqual({
                     first: false
+                });
+        });
+
+        it('should return latest value if there are duplicate keys', function () {
+            expect(state
+                .setState(1, [1, 2])
+                .toObject(['1', '1']))
+                .toEqual({
+                    1: 2
                 });
         });
     });

--- a/spec/State.spec.js
+++ b/spec/State.spec.js
@@ -607,7 +607,7 @@ describe('State:', function () {
         });
 
         it('should be returns empty object if no keys and have results', function () {
-            expect(state.setState(1, [null, 2]).toObject()).toEqual([null, 2]);
+            expect(state.setState(1, [null, 2]).toObject()).toEqual({});
         });
 
         it('should be returns object if have keys and results', function () {
@@ -702,8 +702,8 @@ describe('State:', function () {
     });
 
     it('toJSON', function () {
-        expect(new State().toJSON()).toBeUndefined();
-        expect(new State().setState(1, [1]).toJSON()).toEqual(1);
+        expect(new State().toJSON()).toEqual({});
+        expect(new State().setState(1, [1]).toJSON()).toEqual({});
         expect(new State().setKeys([1]).toJSON()).toEqual({});
         expect(new State().setState(1, null).setKeys([1]).toJSON()).toEqual({1:null});
     });


### PR DESCRIPTION
## CHANGELOG

### Основное:
- Константы событий и состояний вынесены из прототипов в статические свойства соответствующих конструкторов
- Все конструкторы теперь имеют метод `.invoke(fnc, args, context)`

### State:
- Удалены методы `State#bind`, `State#getByKey`, `State#getByIndex`
- Новый метод `State#getStateData(key)`
- По-умолчанию ключами является пустой массив
- Метод `#emit` не переопределяется в `State`
- Метод `State#destroy` теперь принимает необязательный аргумент - `recursive`
- Метод `State#toObject` теперь всегда возвращает объект по ключам без фильтрации по состоянию
- Метод `State#setKeys` по-умолчанию устанавливает пустой массив в `State#keys`

### Response:
- Удалены методы `Response#isCompatible`, `Response#queue`, `Response#callback`, `Response#makeCallback`
- Новые методы `Response#fork()`, `Response#map(listener, context)`
- Метод `Response#always` заменен на `Response#any`
- Метод `Response#notify` теперь полностью поддерживает объект Deferred
- Метод `Response#listen` теперь полностью поддерживает объект Promise
- Метод `Response#getResult` теперь принимает только один аргумент с ключами и возвращает первый результат, если ключей нет
- Метод `Response#getReason` теперь возвращает undefined, если нет ошибки

### Queue:
- Удален метод `Queue#destroyItems`
- Метод `Queue#push` теперь принимает два аргумента - элемент и его ключ
- Свойство `Queue#stack` переименовано в `Queue#items`
- Исправлены ошибки старта и остановки очереди
- Очередь теперь поддерживает объекты Promise в качестве элементов

### Другое:
- Добавлены тесты производительность с прошлой версией
- Обновлены тесты
- Улучшилась производительность