### PR TITLE
Возможность подписки на ошибки элементов очереди

### DIFF
--- a/Response.js
+++ b/Response.js
@@ -1250,14 +1250,16 @@ function iterate(queue) {
 function checkFunction(queue, item) {
     var next = queue.items.shift();
     var results;
+    var context;
 
     if (isFunction(next)) {
         results = Response.isResponse(item) ? item.stateData : [item];
-        next = queue.invoke.call(queue.isStrict ? queue : null, next, results, queue);
-    }
+        context = queue.isStrict ? queue : new State();
+        next = queue.invoke.call(context, next, results, queue);
 
-    if (next instanceof Error) {
-        emit(queue, EVENT_ITEM_FAIL, [next]);
+        if (context.is(STATE_ERROR)) {
+            emit(queue, EVENT_ITEM_FAIL, [next]);
+        }
     }
 
     if (queue.isPending()) {

--- a/Response.js
+++ b/Response.js
@@ -20,7 +20,7 @@ var EVENT_PROGRESS = 'progress';
 var EVENT_START = 'start';
 var EVENT_STOP = 'stop';
 var EVENT_NEXT_ITEM = 'nextItem';
-var EVENT_ITEM_FAIL = 'itemFail';
+var EVENT_ITEM_REJECTED = 'itemRejected';
 
 /**
  * @param {Object} proto
@@ -1214,8 +1214,8 @@ Queue.prototype.onNextItem = function (listener, context) {
  * @param {Object} [context=this]
  * @returns {Queue}
  */
-Queue.prototype.onItemFail = function (listener, context) {
-    this.on(EVENT_ITEM_FAIL, listener, context);
+Queue.prototype.onItemRejected = function (listener, context) {
+    this.on(EVENT_ITEM_REJECTED, listener, context);
 
     return this;
 };
@@ -1258,7 +1258,7 @@ function checkFunction(queue, item) {
         next = queue.invoke.call(context, next, results, queue);
 
         if (context.is(STATE_ERROR)) {
-            emit(queue, EVENT_ITEM_FAIL, [next]);
+            emit(queue, EVENT_ITEM_REJECTED, [next]);
         }
     }
 
@@ -1311,7 +1311,7 @@ function onRejectItem(error) {
         this.item.off(STATE_RESOLVED, onResolveItem);
     }
 
-    emit(this, EVENT_ITEM_FAIL, [error]);
+    emit(this, EVENT_ITEM_REJECTED, [error]);
 
     if (this.isStrict) {
         this.item = null;

--- a/Response.js
+++ b/Response.js
@@ -1254,11 +1254,11 @@ function checkFunction(queue, item) {
 
     if (isFunction(next)) {
         results = Response.isResponse(item) ? item.stateData : [item];
-        context = queue.isStrict ? queue : new State();
+        context = new State();
         next = queue.invoke.call(context, next, results, queue);
 
         if (context.is(STATE_ERROR)) {
-            emit(queue, EVENT_ITEM_REJECTED, [next]);
+            onFunctionError(queue, next);
         }
     }
 
@@ -1270,6 +1270,19 @@ function checkFunction(queue, item) {
     }
 
     return !queue.isStarted;
+}
+
+/**
+ * Обработчик ошибок для элементов очереди типа "function"
+ * @param {Queue} queue
+ * @param {Error} error
+ */
+function onFunctionError (queue, error) {
+    emit(queue, EVENT_ITEM_REJECTED, [error]);
+
+    if (queue.isStrict) {
+        queue.reject(error);
+    }
 }
 
 /**

--- a/spec/Queue.spec.js
+++ b/spec/Queue.spec.js
@@ -358,12 +358,12 @@ describe('Queue:', function () {
             expect(listener.calls.mostRecent().object).toBe(ctx);
         });
 
-        it('on "itemFail" event should not be fired if all items has resolved', function () {
+        it('on "itemRejected" event should not be fired if all items has resolved', function () {
             queue
                 .push(1)
                 .push(function () {})
                 .push((new Response()).resolve())
-                .onItemFail(listener)
+                .onItemRejected(listener)
                 .start();
 
             queue.onResolve(function () {
@@ -371,26 +371,26 @@ describe('Queue:', function () {
             });
         });
 
-        it('on "itemFail" event should be fired with an error as argument', function () {
+        it('on "itemRejected" event should be fired with an error as argument', function () {
             var error = new Error();
 
             queue
                 .push(function () {
                     throw error;
                 })
-                .onItemFail(function (_error) {
+                .onItemRejected(function (_error) {
                     expect(_error).toBe(error);
                 })
                 .start();
         });
 
-        it('on "itemFail" event should fire for rejected Response', function () {
+        it('on "itemRejected" event should fire for rejected Response', function () {
             var resp = new Response();
             resp.reject(new Error());
 
             queue
                 .push(resp)
-                .onItemFail(listener)
+                .onItemRejected(listener)
                 .start();
 
             queue.onResolve(function () {
@@ -398,12 +398,12 @@ describe('Queue:', function () {
             });
         });
 
-        it('on "itemFail" event should fire for rejected function', function () {
+        it('on "itemRejected" event should fire for rejected function', function () {
             queue
                 .push(function () {
                     throw new Error();
                 })
-                .onItemFail(listener)
+                .onItemRejected(listener)
                 .start();
 
             queue.onResolve(function () {
@@ -411,7 +411,7 @@ describe('Queue:', function () {
             });
         });
 
-        it('on "itemFail" event should fire once for each rejected item', function () {
+        it('on "itemRejected" event should fire once for each rejected item', function () {
             function failingFn () {
                 throw new Error();
             }
@@ -420,19 +420,19 @@ describe('Queue:', function () {
                 .push(failingFn)
                 .push((new Response()).reject(new Error()))
                 .push(2)
-                .onItemFail(listener)
+                .onItemRejected(listener)
                 .onResolve(function () {
                     expect(listener.calls.count()).toBe(2);
                 })
                 .start();
         });
 
-        it('on "itemFail" should not fire if function has returned an Error object', function () {
+        it('on "itemRejected" should not fire if function has returned an Error object', function () {
             queue
                 .push(function () {
                     return new Error();
                 })
-                .onItemFail(listener)
+                .onItemRejected(listener)
                 .onResolve(function () {
                     expect(listener.calls.count()).toBe(0);
                 })

--- a/spec/Queue.spec.js
+++ b/spec/Queue.spec.js
@@ -438,6 +438,44 @@ describe('Queue:', function () {
                 })
                 .start();
         });
+
+        it('on "itemRejected" should be fired before strict queue reject (function)', function () {
+            var onItemRejectedCalled = false;
+            var onRejectedCalled = false;
+
+            queue
+                .strict()
+                .push(function () {
+                    throw new Error();
+                })
+                .onItemRejected(function () {
+                    onItemRejectedCalled = true;
+                    expect(onRejectedCalled).toBe(false);
+                })
+                .onReject(function () {
+                    onRejectedCalled = true;
+                    expect(onItemRejectedCalled).toBe(true);
+                })
+                .start();
+        });
+
+        it('on "itemRejected" should be fired before strict queue reject (Response)', function () {
+            var onItemRejectedCalled = false;
+            var onRejectedCalled = false;
+
+            queue
+                .strict()
+                .push((new Response()).reject(new Error()))
+                .onItemRejected(function () {
+                    onItemRejectedCalled = true;
+                    expect(onRejectedCalled).toBe(false);
+                })
+                .onReject(function () {
+                    onRejectedCalled = true;
+                    expect(onItemRejectedCalled).toBe(true);
+                })
+                .start();
+        });
     });
 
     describe('destroy', function () {

--- a/spec/Queue.spec.js
+++ b/spec/Queue.spec.js
@@ -426,6 +426,18 @@ describe('Queue:', function () {
                 })
                 .start();
         });
+
+        it('on "itemFail" should not fire if function has returned an Error object', function () {
+            queue
+                .push(function () {
+                    return new Error();
+                })
+                .onItemFail(listener)
+                .onResolve(function () {
+                    expect(listener.calls.count()).toBe(0);
+                })
+                .start();
+        });
     });
 
     describe('destroy', function () {


### PR DESCRIPTION
Сейчас в нестрогой очереди необходимо вручную следить за упавшими элементами очереди (например, если хочется залогировать ошибки). Этот PR позволяет навесить обработчик ошибок отдельных элементов очереди.
```javascript
queue
  .push(function () {
    throw new Error();
  })
  .onItemFail(function (error) {
     console.error(error);
  })
  .start();
```
Это первый шаг к тому, чтобы не пропускать логирование важных ошибок, дальше можно будет реализовать дефолтный логгер для ошибок очереди.