### PR TITLE
Не передавать undefined в следующую задачу

### DIFF
--- a/Response.js
+++ b/Response.js
@@ -1239,7 +1239,7 @@ function checkFunction(queue, item) {
     var results;
 
     if (isFunction(next)) {
-        results = Response.isResponse(item) ? item.stateData : [item];
+        results = Response.isResponse(item) ? item.stateData : toArray(item);
         next = queue.invoke.call(queue.isStrict ? queue : null, next, results, queue);
     }
 
@@ -1408,6 +1408,15 @@ function destroyItems(items) {
  */
 function toObject(item) {
     return (item && item.toObject) ? item.toObject() : item;
+}
+
+/**
+ *
+ * @param {*} item
+ * @returns {Array}
+ */
+function toArray(item) {
+    return (item === undefined) ? [] : [item];
 }
 
 /**

--- a/spec/Queue.spec.js
+++ b/spec/Queue.spec.js
@@ -623,6 +623,16 @@ describe('Queue:', function () {
                 expect(this.item).toBe(r2);
             }], true);
         });
+
+        it('should not pass undefined to next task', function () {
+            queue
+                .push(function task1 () {
+
+                })
+                .push(function task2 () {
+                    expect(arguments.length).toBe(0);
+                });
+        });
     });
 
     it('getResult should be returns result if state is pending', function () {
@@ -635,5 +645,5 @@ describe('Queue:', function () {
                 });
             })
             .start();
-    })
+    });
 });


### PR DESCRIPTION
Сейчас в очереди не будет работать проверка на arguments.length в задаче, т.к. в задачу в любом случае передается один аргумент "undefined". Этот PR фиксит эту проблему.
```javascript
queue
  .push(function task1 () {
    // ничего не возвращаем
  })
  .push(function task2 () {
    console.log(arguments.length); // 1
  });
```