### PR TITLE
Feature/queue start arguments

### DIFF
--- a/Response.js
+++ b/Response.js
@@ -1106,8 +1106,7 @@ Queue.prototype.start = function (args) {
             this.reject(new Error('start arguments must be an array'));
         }
 
-        var argsWrap = new Response();
-        this.item = argsWrap.resolve.apply(argsWrap, args);
+        this.item = (new Response()).setState(Response.STATE_RESOLVED, args);
     }
 
     if (this.isStarted === false && this.isPending()) {

--- a/Response.js
+++ b/Response.js
@@ -1097,23 +1097,17 @@ Queue.prototype.items = null;
 Queue.prototype.item = null;
 
 /**
- * @readonly
- * @type {Array|null}
- * @default null
- */
-Queue.prototype.startArgs = null;
-
-/**
- *
+ * @param {Array} args - аргументы для первой задачи
  * @returns {Queue}
  */
 Queue.prototype.start = function (args) {
-    if (args !== undefined) {
+    if (arguments.length > 0) {
         if (!isArray(args)) {
             this.reject(new Error('start arguments must be an array'));
         }
 
-        this.startArgs = args;
+        var argsWrap = new Response();
+        this.item = argsWrap.resolve.apply(argsWrap, args);
     }
 
     if (this.isStarted === false && this.isPending()) {
@@ -1254,13 +1248,7 @@ function checkFunction(queue, item) {
     var results;
 
     if (isFunction(next)) {
-        if (queue.startArgs) {
-            results = queue.startArgs;
-            queue.startArgs = null;
-        } else {
-            results = Response.isResponse(item) ? item.stateData : toArray(item);
-        }
-
+        results = Response.isResponse(item) ? item.stateData : toArray(item);
         next = queue.invoke.call(queue.isStrict ? queue : null, next, results, queue);
     }
 

--- a/Response.js
+++ b/Response.js
@@ -1097,10 +1097,25 @@ Queue.prototype.items = null;
 Queue.prototype.item = null;
 
 /**
+ * @readonly
+ * @type {Array|null}
+ * @default null
+ */
+Queue.prototype.startArgs = null;
+
+/**
  *
  * @returns {Queue}
  */
-Queue.prototype.start = function () {
+Queue.prototype.start = function (args) {
+    if (args !== undefined) {
+        if (!isArray(args)) {
+            this.reject(new Error('start arguments must be an array'));
+        }
+
+        this.startArgs = args;
+    }
+
     if (this.isStarted === false && this.isPending()) {
         this.isStarted = true;
 
@@ -1239,7 +1254,13 @@ function checkFunction(queue, item) {
     var results;
 
     if (isFunction(next)) {
-        results = Response.isResponse(item) ? item.stateData : [item];
+        if (queue.startArgs) {
+            results = queue.startArgs;
+            queue.startArgs = null;
+        } else {
+            results = Response.isResponse(item) ? item.stateData : [item];
+        }
+
         next = queue.invoke.call(queue.isStrict ? queue : null, next, results, queue);
     }
 

--- a/spec/Queue.spec.js
+++ b/spec/Queue.spec.js
@@ -472,6 +472,37 @@ describe('Queue:', function () {
                 expect(listener).toHaveBeenCalledWith();
                 expect(listener.calls.mostRecent().object).toBe(queue);
             });
+
+            it('start should accept arguments for first task', function () {
+                var testArg1 = {};
+                var testArg2=  {};
+
+                queue
+                    .push(function (arg1, arg2) {
+                        expect(arg1).toBe(testArg1);
+                        expect(arg2).toBe(testArg2);
+                    })
+                    .start([testArg1, testArg2]);
+            });
+
+            it('start arguments should not propagate to second task', function () {
+                queue
+                    .push(function task1 () {
+                    })
+                    .push(function task2 () {
+                        console.log(arguments);
+                        expect(arguments.length).toBe(0);
+                    })
+                    .start([1, 2]);
+            });
+
+            it('start arguments should be an array', function () {
+                queue.start(null);
+                expect(queue.isRejected()).toBeTruthy();
+                queue.onReject(function (error) {
+                    expect(error).toEqual(jasmine.any(Error));
+                });
+            });
         });
 
         describe('after stopping', function () {

--- a/spec/Queue.spec.js
+++ b/spec/Queue.spec.js
@@ -490,7 +490,6 @@ describe('Queue:', function () {
                     .push(function task1 () {
                     })
                     .push(function task2 () {
-                        console.log(arguments);
                         expect(arguments.length).toBe(0);
                     })
                     .start([1, 2]);


### PR DESCRIPTION
Добавлена возможность указать аргументы для первого таска в методе ```.start()```.
Раньше, чтобы указать несколько аргументов нужно было делать так:
```javascript
queue
  .push(R.resolve(1, 2))
  .push(function task (one, two) {
  });
```
Теперь можно будет так:
```javascript
queue
  .push(function task (one, two) {

  });
  .start([1, 2]);
```