### PR TITLE
Added logging unhandled rejections. Fixed Queue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "6.9.5"
 sudo: required

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "Response",
     "author": "Vladislav Kurkin <b-vladi@cs-console.ru> (https://github.com/B-Vladi)",
-    "version": "0.1.11",
+    "version": "0.1.12",
     "main": "Response.js",
     "license": "MIT",
     "repository": {

--- a/spec/Queue.spec.js
+++ b/spec/Queue.spec.js
@@ -846,12 +846,13 @@ describe('Queue:', function () {
     describe('External errors:', function () {
         var faultyListener;
         var goodListener;
+        var error = new Error('handler throws');
 
         beforeEach(function () {
             faultyListener = jasmine
                 .createSpy('faultyListener').and
                 .callFake(function throwsError() {
-                    throw new Error('handler throws');
+                    throw error;
                 });
 
             goodListener = jasmine.createSpy('goodListener');
@@ -884,7 +885,7 @@ describe('Queue:', function () {
 
             item.reject(new Error('item fails'));
 
-            expect(goodListener).toHaveBeenCalled();
+            expect(goodListener).toHaveBeenCalledWith(item);
         });
 
         it('rejects if .strict and .onReject for an item throws an error', function () {
@@ -900,7 +901,7 @@ describe('Queue:', function () {
 
             item.reject(new Error('item fails'));
 
-            expect(goodListener).toHaveBeenCalled();
+            expect(goodListener).toHaveBeenCalledWith(error);
         });
     });
 });

--- a/spec/State.spec.js
+++ b/spec/State.spec.js
@@ -340,6 +340,62 @@ describe('State:', function () {
 
             expect(listener).not.toHaveBeenCalled();
         });
+
+        describe('should be emit "unhandledStateError" on process', function () {
+            it('if the state does not have event listeners', function (done) {
+                var error = new Error();
+
+                process.on('unhandledStateError', listener);
+
+                state.setState('error', error);
+
+                expect(listener).not.toHaveBeenCalled();
+
+                process.nextTick(function () {
+                    expect(listener).toHaveBeenCalledWith(error, state);
+
+                    done();
+                })
+            });
+        });
+
+        describe('should not be emit "unhandledStateError" on process', function () {
+            it('if the state have event listeners', function (done) {
+                var error = new Error();
+
+                process.on('unhandledStateError', listener);
+
+                state
+                    .onState('error', () => {})
+                    .setState('error', error);
+
+                expect(listener).not.toHaveBeenCalled();
+
+                process.nextTick(function () {
+                    expect(listener).not.toHaveBeenCalled();
+
+                    done();
+                })
+            });
+
+            it('if the state have once event listeners', function (done) {
+                var error = new Error();
+
+                process.on('unhandledStateError', listener);
+
+                state
+                    .onceState('error', () => {})
+                    .setState('error', error);
+
+                expect(listener).not.toHaveBeenCalled();
+
+                process.nextTick(function () {
+                    expect(listener).not.toHaveBeenCalled();
+
+                    done();
+                })
+            });
+        });
     });
 
     describe('state data', function () {


### PR DESCRIPTION
1. Генерируется событие `"unhandledStateError"` на объекте `process`, если экземпляр `State` не имеет обработчиков `error`.
2. Исправлена обработка reject-а элемента очереди.