### PR TITLE
Fix: npm install fails, karma test fails

### DIFF
--- a/Response.js
+++ b/Response.js
@@ -1429,7 +1429,8 @@ function changeState(object, state, data) {
     object.state = state;
 
     if (state === STATE_ERROR && object.listenerCount(state) === 0) {
-        process.nextTick(() => {
+
+        process.nextTick(function () {
             if (object.is(state) && !object.listenerCount(state)) {
                 process.emit('unhandledStateError', data[0], object);
             }

--- a/package.json
+++ b/package.json
@@ -15,13 +15,15 @@
         "EventEmitter": "B-Vladi/EventEmitter.git#0.2.6"
     },
     "devDependencies": {
-        "jasmine": "2.0.1",
+        "browserify": "^14.5.0",
+        "jasmine": "^2.8.0",
         "jasmine-node": "^1.14.5",
-        "karma": "^0.12.24",
-        "karma-jasmine": "^0.2.3",
-        "karma-browserify": "^2.0.0",
-        "karma-chrome-launcher": "^0.1.5",
-        "karma-phantomjs-launcher": "^0.1.4"
+        "karma": "^1.7.1",
+        "karma-browserify": "^5.1.2",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-jasmine": "^1.1.1",
+        "karma-phantomjs-launcher": "^1.0.4",
+        "watchify": "^3.9.0"
     },
     "contributors": [
         "Igor Zarutskiy <igorzarut@yandex-team.ru>"


### PR DESCRIPTION
1. `npm install` падает при установке зависимости из browserify, потому что удалили репозиторий зависимого пакета

```mac ~/github/alekzonder/Response (master) $ npm i
...
npm ERR! Command failed: git clone --template=~/.npm/_git-remotes/_templates --mirror git@github.com:nikku/node-browserify.git ~/.npm/_git-remotes/git-github-com-nikku-node-browserify-git-local-fix-b3c0abb5
npm ERR! Cloning into bare repository '/tmp/.npm/_git-remotes/git-github-com-nikku-node-browserify-git-local-fix-b3c0abb5'...
npm ERR! ERROR: Repository not found.
npm ERR! fatal: Could not read from remote repository.
npm ERR!
npm ERR! Please make sure you have the correct access rights
npm ERR! and the repository exists.
npm ERR!
...
```

2. Не проходили тесты в karma, потому что:
- были три arrow-функции, а phantom не может распарсить такой js
- в браузере объект process создается модулем [process](https://github.com/defunctzombie/node-process/blob/master/browser.js#L164) и там методы .on, .emit просто noop-заглушки

пока сделал переопределение методов process.on, process.emit для тестов в браузере